### PR TITLE
Upload without vm

### DIFF
--- a/application/src/tira/authentication.py
+++ b/application/src/tira/authentication.py
@@ -5,9 +5,13 @@ import json
 import logging
 import os
 from datetime import datetime
+from functools import wraps
 
 import requests
 from django.conf import settings
+from django.http import JsonResponse, Http404, HttpResponseNotAllowed
+import tira.tira_model as model
+
 from google.protobuf.text_format import Parse
 
 from .proto import TiraClientWebMessages_pb2 as modelpb
@@ -41,6 +45,10 @@ class Authentication(object):
 
     def __init__(self, **kwargs):
         pass
+
+    @staticmethod
+    def get_default_vm_id(user_id):
+        return f"{user_id}-default"
 
     def get_role(self, request, user_id: str = None, vm_id: str = None, task_id: str = None):
         """ Determine the role of the user on the requested page (determined by the given directives).
@@ -84,13 +92,6 @@ class LegacyAuthentication(Authentication):
         - :param users_file: path to the users.prototext that contains the user data
         """
         super(LegacyAuthentication, self).__init__(**kwargs)
-        self.users = {}
-        self.users_file = kwargs["users_file"]
-        self.load_legacy_users()
-
-    def load_legacy_users(self):
-        users = Parse(open(self.users_file, "r").read(), modelpb.Users())
-        self.users = {user.userName: user for user in users.users}
 
     def login(self, request, **kwargs):
         """ Set a user_id cookie to the django session
@@ -99,8 +100,8 @@ class LegacyAuthentication(Authentication):
         - :param password:
         """
         try:
-            user = self.users.get(kwargs["user_id"])
-            if kwargs["password"] == user.userPw:
+            user = model.get_vm(kwargs["user_id"])
+            if kwargs["password"] == user['user_password']:
                 request.session["user_id"] = kwargs["user_id"]
             else:
                 return False
@@ -115,7 +116,6 @@ class LegacyAuthentication(Authentication):
         except KeyError:
             pass
 
-    # TODO permission logic should be in check.
     def get_role(self, request, user_id: str = None, vm_id: str = None, task_id: str = None):
         """ Determine the role of the user on the requested page (determined by the given directives).
         This is a minimalistic implementation using the legacy account storage.
@@ -124,53 +124,65 @@ class LegacyAuthentication(Authentication):
 
         Currently only checks: (1) is user admin, (2) otherwise, is user owner of the vm (ROLE_PARTICIPANT)
         """
-        user = self.users.get(user_id, None)
-        if not user_id or not user:
+        if not user_id:
+            return self.ROLE_GUEST
+        user = model.get_vm(user_id)
+        if not user:
             return self.ROLE_GUEST
 
-        if 'reviewer' in {role for role in user.roles}:
+        if 'reviewer' in {role for role in user['roles']}:
             return self.ROLE_ADMIN
         # NOTE: in the old user management vm_id == user_id
-        if user_id == vm_id:
+        if user_id == vm_id or Authentication.get_default_vm_id(user_id) == vm_id:
             return self.ROLE_PARTICIPANT
 
-        if user_id != vm_id and vm_id is not None and vm_id != 'no-vm-assigned':
+        if user_id != vm_id and vm_id is not None and vm_id != Authentication.get_default_vm_id(user_id):
             return self.ROLE_FORBIDDEN
 
         return self.ROLE_USER
 
+    # TODO creating the default user should be done at some other point that's less frequently called.
     def get_user_id(self, request):
+        user_id = request.session.get("user_id", None)
+        if user_id:
+            vm_id = Authentication.get_default_vm_id(user_id)
+            _ = model.get_vm(vm_id, create_if_none=True)
+
         return request.session.get("user_id", None)
 
     def get_vm_id(self, request, user_id):
         """ Note: in the old schema, user_id == vm_id"""
-        user = self.users.get(user_id, None)
-        if user and user.vmName:
+        user = model.get_vm(user_id)
+        if user and user['host']:  # i.e. if there is a host somewhere
             return user_id
-        return "no-vm-assigned"
+        return Authentication.get_default_vm_id(user_id)
+
+
+def check_disraptor_token(func):
+    @wraps(func)
+    def func_wrapper(request, *args, **kwargs):
+        _DISRAPTOR_APP_SECRET_KEY = os.getenv("DISRAPTOR_APP_SECRET_KEY")
+
+        if not request.headers.get('X-Disraptor-App-Secret-Key', None) == _DISRAPTOR_APP_SECRET_KEY:
+            return HttpResponseNotAllowed(f"Access forbidden.")
+
+        return func(request, *args, **kwargs)
+
+    return func_wrapper
 
 
 class DisraptorAuthentication(Authentication):
     _AUTH_SOURCE = "disraptor"
-    _DISRAPTOR_APP_SECRET_KEY = os.getenv("DISRAPTOR_APP_SECRET_KEY")
 
-    # TODO should be in check
-    def _reply_if_allowed(self, request, response, alternative="None"):
-        """ Returns the :param response: if disraptor auth token is correct, otherwise returns the :param alternative:
-        """
-        if request.headers.get('X-Disraptor-App-Secret-Key', None) == self._DISRAPTOR_APP_SECRET_KEY:
-            return response
-        else:
-            return alternative
-
-    @staticmethod
-    def _get_user_id(request):
+    def _get_user_id(self, request):
         """ Return the content of the X-Disraptor-User header set in the http request """
         user_id = request.headers.get('X-Disraptor-User', None)
+        if user_id:
+            vm_id = Authentication.get_default_vm_id(user_id)
+            _ = model.get_vm(vm_id, create_if_none=True)
         return user_id
 
-    @staticmethod
-    def _is_in_group(request, group_name='tira_reviewer') -> bool:
+    def _is_in_group(self, request, group_name='tira_reviewer') -> bool:
         """ return True if the user is in the given disraptor group"""
         return group_name in request.headers.get('X-Disraptor-Groups', "").split(",")
 
@@ -196,12 +208,13 @@ class DisraptorAuthentication(Authentication):
         @param group_type: {"vm"}, indicate the class of groups.
         """
         all_groups = request.headers.get('X-Disraptor-Groups', "None").split(",")
+        user_id = f"{request.headers.get('X-Disraptor-User', None)}-default"
 
         if group_type == 'vm':  # if we check for groups of a virtual machine
-            return [group["value"] for group in self._parse_tira_groups(all_groups) if group["key"] == "vm"]
+            return [group["value"] for group in self._parse_tira_groups(all_groups) if group["key"] == "vm"] + [user_id]
             # return [u.split("-")[2:] for u in all_groups if u.startswith("tira-vm-")]
 
-    # TODO: permission logic should be in Check
+    @check_disraptor_token
     def get_role(self, request, user_id: str = None, vm_id: str = None, task_id: str = None):
         """ Determine the role of the user on the requested page (determined by the given directives).
         This is a minimalistic implementation that suffices for the current features of TIRA.
@@ -212,30 +225,33 @@ class DisraptorAuthentication(Authentication):
         """
 
         if self._is_in_group(request, "admins") or self._is_in_group(request, "tira_reviewer"):
-            return self._reply_if_allowed(request, self.ROLE_ADMIN, self.ROLE_GUEST)
+            return self.ROLE_ADMIN
 
         user_groups = self._get_user_groups(request, group_type='vm')
         # Role for users with permissions for the vm
         if vm_id in user_groups:
-            return self._reply_if_allowed(request, self.ROLE_PARTICIPANT, self.ROLE_GUEST)
-        # Role for registered
+            return self.ROLE_PARTICIPANT
         elif user_id and not vm_id:
-            return self._reply_if_allowed(request, self.ROLE_USER, self.ROLE_GUEST)
+            return self.ROLE_USER
         # Role without permissions for the vm
         elif user_id and vm_id in user_groups:
-            return self._reply_if_allowed(request, self.ROLE_FORBIDDEN, self.ROLE_GUEST)
+            return self.ROLE_FORBIDDEN
         return self.ROLE_GUEST
 
+    @check_disraptor_token
     def get_user_id(self, request):
         """ public wrapper of _get_user_id that checks conditions """
-        return self._reply_if_allowed(request, self._get_user_id(request))
+        return self._get_user_id(request)
 
+    @check_disraptor_token
     def get_vm_id(self, request, user_id=None):
         """ return the vm_id of the first vm_group ("tira-vm-<vm_id>") found.
          If there is no vm-group, return "no-vm-assigned"
+         TODO: once multiple vms are supported, this should return a list
          """
         vms = self._get_user_groups(request)
-        return vms[0] if len(vms) >= 1 else "no-vm-assigned"
+        user_id = self._get_user_id(request)
+        return vms[0] if len(vms) >= 1 else Authentication.get_default_vm_id(user_id)
 
     def _discourse_api_key(self):
         return open(settings.DISRAPTOR_SECRET_FILE, "r").read().strip()
@@ -293,5 +309,4 @@ class DisraptorAuthentication(Authentication):
         return message
 
 
-auth = Authentication(authentication_source=settings.DEPLOYMENT,
-                      users_file=settings.LEGACY_USER_FILE)
+auth = Authentication(authentication_source=settings.DEPLOYMENT)

--- a/application/src/tira/authentication.py
+++ b/application/src/tira/authentication.py
@@ -130,8 +130,9 @@ class LegacyAuthentication(Authentication):
         if not user:
             return self.ROLE_GUEST
 
-        if 'reviewer' in {role for role in user['roles']}:
+        if 'reviewer' in user['roles']:
             return self.ROLE_ADMIN
+
         # NOTE: in the old user management vm_id == user_id
         if user_id == vm_id or Authentication.get_default_vm_id(user_id) == vm_id:
             return self.ROLE_PARTICIPANT

--- a/application/src/tira/checks.py
+++ b/application/src/tira/checks.py
@@ -29,11 +29,14 @@ def check_permissions(func):
         dataset_id = kwargs.get('dataset_id', None)
         run_id = kwargs.get('run_id', None)
         role = auth.get_role(request, user_id=auth.get_user_id(request))
+        print(role)
 
         if role == auth.ROLE_ADMIN or role == auth.ROLE_TIRA:
             return func(request, *args, **kwargs)
 
         if vm_id:
+            if not model.vm_exists(vm_id):
+                return redirect('tira:request_vm')
             role = auth.get_role(request, user_id=auth.get_user_id(request), vm_id=vm_id)
             if run_id and dataset_id:
                 if not model.run_exists(vm_id, dataset_id, run_id):
@@ -85,6 +88,8 @@ def check_conditional_permissions(restricted=False, public_data_ok=False, privat
                 return HttpResponseNotAllowed(f"Access restricted.")
 
             if vm_id:
+                if not model.vm_exists(vm_id):
+                    return redirect('tira:request_vm')
                 role_on_vm = auth.get_role(request, user_id=auth.get_user_id(request), vm_id=vm_id)
                 if run_id and dataset_id:
                     role = auth.ROLE_USER

--- a/application/src/tira/data/FileDatabase.py
+++ b/application/src/tira/data/FileDatabase.py
@@ -549,7 +549,7 @@ class FileDatabase(object):
     # get methods are the public interface.
     ###################################
 
-    def get_vm(self, vm_id: str):
+    def get_vm(self, vm_id: str, create_if_none=False):
         # TODO should return as dict
         return self.vms.get(vm_id, None)
 

--- a/application/src/tira/data/HybridDatabase.py
+++ b/application/src/tira/data/HybridDatabase.py
@@ -321,8 +321,11 @@ class HybridDatabase(object):
                 "host": vm.host, "admin_name": vm.admin_name, "admin_pw": vm.admin_pw,
                 "ip": vm.ip, "ssh": vm.ssh, "rdp": vm.rdp, "archived": vm.archived}
 
-    def get_vm(self, vm_id: str):
-        vm = modeldb.VirtualMachine.objects.get(vm_id=vm_id)
+    def get_vm(self, vm_id: str, create_if_none=False):
+        if create_if_none:
+            vm, _ = modeldb.VirtualMachine.objects.get_or_create(vm_id=vm_id)
+        else:
+            vm = modeldb.VirtualMachine.objects.get(vm_id=vm_id)
         return self._vm_as_dict(vm)
 
     def get_users_vms(self):

--- a/application/src/tira/endpoints/vm_api.py
+++ b/application/src/tira/endpoints/vm_api.py
@@ -154,10 +154,11 @@ def vm_stop(request, vm_id):
 @check_permissions
 @check_resources_exist('json')
 def vm_info(request, vm_id):
-    # TODO when vm_id is no-vm-assigned
-
     vm = model.get_vm(vm_id)
     host = reroute_host(vm['host'])
+    if not host:
+        logger.exception(f"/grpc/{vm_id}/vm-info: connection to {host} failed, because host is empty")
+        return JsonResponse({'status': 'Rejected', 'message': "SERVER_ERROR"}, status=HTTPStatus.INTERNAL_SERVER_ERROR)
     try:
         grpc_client = GrpcClient(host)
         response_vm_info = grpc_client.vm_info(vm_id=vm_id)

--- a/application/src/tira/static/tira/js/software.js
+++ b/application/src/tira/static/tira/js/software.js
@@ -4,6 +4,9 @@ let pollingEvaluation=false;
 let state=0;
 
 function setupPollingAfterPageLoad(vmid) {
+    if(vmid.endsWith('default')){
+        return
+    }
     $('.run-evaluate-spinner').hide()
     setState()
     loadVmInfo(vmid)

--- a/application/src/tira/templates/tira/base.html
+++ b/application/src/tira/templates/tira/base.html
@@ -15,17 +15,18 @@
 
     <link rel="stylesheet" type="text/css" href="{% static 'tira/css/tira-style.css' %}">
 </head>
-<body class="uk-offcanvas-content">
+<body class="uk-offcanvas-content uk-flex uk-flex-between uk-flex-column" uk-height-viewport="min-height: 100vh">
 <script src="https://assets.webis.de/js/thirdparty/uikit/uikit.min.js"></script>
 <script src="https://assets.webis.de/js/thirdparty/uikit/uikit-icons.min.js"></script>
 
+
+<div class="uk-flex-none">
 {% block navbar %}{% endblock %}
-
-<div>
-    {% block content %}{% endblock %}
+{% block content %}{% endblock %}
 </div>
+<div class="uk-flex-wrap-stretch"></div>
 
-<footer class="uk-section uk-section-muted footer-section uk-padding-small uk-position-bottom">
+<footer class="uk-section uk-section-muted footer-section uk-padding-small uk-flex-none">
     <div class="uk-container uk-margin-small-top">
         <div class="uk-align-right@m">
             Copyright &copy; {% now "Y" %} <a href="https://webis.de/">Webis group</a> <span class="uk-padding-small">&bullet;</span>

--- a/application/src/tira/templates/tira/index.html
+++ b/application/src/tira/templates/tira/index.html
@@ -20,7 +20,6 @@
     </div>
     <div class="uk-position-bottom-right uk-light uk-margin-right"><a href="https://www.shutterstock.com/image-photo/sunset-oia-santorini-greece-1005762703" target="_blank">Shutterstock</a></div>
 </main>
-
 <div class="uk-section uk-section-default">
     <!-- search field -->
 

--- a/application/src/tira/templates/tira/request_vm.html
+++ b/application/src/tira/templates/tira/request_vm.html
@@ -25,7 +25,6 @@
             </div>
         </div>
      </div>
-
 </main>
 
 {% if not include_navigation %}

--- a/application/src/tira/templates/tira/software.html
+++ b/application/src/tira/templates/tira/software.html
@@ -15,7 +15,7 @@
 
 <main class="uk-section uk-section-default">
     <div class="uk-container">
-        <h1>Virtual Machine &mdash; <span class="uk-text-muted">{{ vm_id }}</span></h1>
+        <h1>Submissions to {{ task.task_name }} &mdash; <span class="uk-text-muted">{{ vm_id }}</span></h1>
     </div>
     {% if vm_id == 'no-vm-assigned' %}
      <div class="uk-container uk-margin-medium">
@@ -29,6 +29,8 @@
     {% else %}
     <!-- VM State and general options   -->
     <div class="uk-container uk-margin-medium">
+
+        {% if not is_default %}
         <div class="uk-grid-small uk-grid-match" uk-grid>
             <div class="uk-card uk-card-small uk-card-body uk-card-default uk-width-1-2">
                 <table>
@@ -152,8 +154,19 @@
                         class="uk-button uk-button-disabled uk-text-center uk-width-1-1" disabled>Abort Run</button>
             </div>
         </div>
+        {% else %}
+        <div class="uk-container uk-margin-medium">
+            <div class="uk-grid-small uk-grid-match" uk-grid>
+                <div class="uk-card uk-card-body uk-card-default">
+                    <b>No Virtual Machine.</b>
+                    Your TIRA account is currently not associated with a virtual machine.
+                    Without a VM, you can only use 'Upload' to submit results.
+                    Please contact your task organizer to obtain a TIRA virtual machine.
+                </div>
+            </div>
+        </div>
+        {% endif %}
     </div>
-
     <div class="uk-container uk-margin-small">
         <h2>Software</h2>
 
@@ -161,9 +174,11 @@
             {% for sw in software %}
             <li><a href="#">{{ sw.software.id }}</a></li>
             {% endfor %}
+            {% if not is_default %}
             <li id="add-software">
                 <a><span class="uk-margin-small-right">+</span>Add Software</a>
             </li>
+            {% endif %}
             <li>
                 <a href="#">Uploads</a>
             </li>
@@ -172,7 +187,9 @@
             {% for sw in software %}
                 {% include "tira/software_form.html" with software=sw.software runs=sw.runs task_id=task.task_id vm_id=vm_id%}
             {% endfor %}
+            {% if not is_default %}
             <li id="add-software-row">add software</li>
+            {% endif %}
             {% include "tira/upload_form.html" with task_id=task.task_id vm_id=vm_id upload=upload %}
         </ul>
 
@@ -223,11 +240,7 @@
 <script src="https://assets.webis.de/js/thirdparty/fontawesome/fontawesome.min.js"></script>
 <script src="https://assets.webis.de/js/thirdparty/fontawesome/solid.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-<!--<script src="https://assets.webis.de/js/filter.js"></script>-->
-<!--<script src="https://assets.webis.de/js/selection.js"></script>-->
-<!--<script src="https://assets.webis.de/js/tables.js"></script>-->
-<!--<script>initWebisTableFiltering();</script>-->
-<!--<script>initTableSorting();</script>-->
+
 <script src="{% static 'tira/js/util.js' %}"></script>
 <script src="{% static 'tira/js/software.js' %}"></script>
 <script>

--- a/application/src/tira/tira_model.py
+++ b/application/src/tira/tira_model.py
@@ -37,7 +37,7 @@ def reload_runs(vm_id):
 
 
 # get methods are the public interface.
-def get_vm(vm_id: str):
+def get_vm(vm_id: str, create_if_none=False):
     """ Returns a vm as dictionary with:
 
         {"vm_id", "user_password", "roles", "host", "admin_name",
@@ -45,7 +45,7 @@ def get_vm(vm_id: str):
 
     Some fields may be None.
     """
-    return model.get_vm(vm_id)
+    return model.get_vm(vm_id, create_if_none)
 
 
 def get_tasks() -> list:

--- a/application/src/tira/urls.py
+++ b/application/src/tira/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('task/<str:task_id>/user/<str:vm_id>/dataset/<str:dataset_id>/download/<str:run_id>.zip', views.download_rundir, name='download_rundir'),
     path('task/<str:task_id>/user/<str:vm_id>', views.software_detail, name='software-detail'),
     path('task/<str:task_id>/user/<str:vm_id>/dataset/<str:dataset_id>/run/<str:run_id>', views.review, name='review'),
+    # path('software/<str:task_id>', views.software, name='software'),
 
     path('request_vm', views.request_vm, name='request_vm'),
     path('login', views.login, name='login'),

--- a/application/src/tira/views.py
+++ b/application/src/tira/views.py
@@ -36,7 +36,9 @@ def add_context(func):
 @add_context
 def index(request, context):
     context["tasks"] = model.get_tasks()
-    context["vm_id"] = auth.get_vm_id(request, context["user_id"])
+    if context["role"] != auth.ROLE_GUEST:
+        context["vm_id"] = auth.get_vm_id(request, context["user_id"])
+
     return render(request, 'tira/index.html', context)
 
 
@@ -62,7 +64,6 @@ def login(request, context):
     """
 
     if request.method == "POST":
-        form = LoginForm(request.POST)
         form = LoginForm(request.POST)
         if form.is_valid():
             # read form data, do auth.login(request, user_id, password)
@@ -136,6 +137,7 @@ def software_detail(request, context, task_id, vm_id):
     context["software"] = software
     context["datasets"] = model.get_datasets_by_task(task_id)
     context["upload"] = upload
+    context["is_default"] = vm_id.endswith("default")
 
     return render(request, 'tira/software.html', context)
 

--- a/application/src/tira/views.py
+++ b/application/src/tira/views.py
@@ -234,7 +234,6 @@ def download_rundir(request, task_id, dataset_id, vm_id, run_id):
         return JsonResponse({'status': 1, 'reason': f'File does not exist: {zipped}'},
                             status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
-@check_permissions
 @add_context
 def request_vm(request, context):
     return render(request, 'tira/request_vm.html', context)


### PR DESCRIPTION
This PR allows users to upload results even if they have no VM assigned. 

Internally, I create a dummy vm for each user based on it's user_id (<user_id>-default). If the user has no other vms, he gets forwarded to the software-page of the dummy vm. The software page detects this and only renders the upload. 

@BastianGrahm Please check if this works with disraptor (it uses a different authentication class).