### PR TITLE
install wheel in venv

### DIFF
--- a/application/Makefile
+++ b/application/Makefile
@@ -28,6 +28,7 @@ setup:
 venv:
 	test -d $(VENV_NAME) || python3 -m venv $(VENV_NAME)
 	sh -c ". $(VENV_NAME)/bin/activate && \
+		python3 -m pip install wheel && \
 		python3 -m pip install -r requirements.txt"
 
 run-develop: venv


### PR DESCRIPTION
Installing wheel to fix the problem is technically optional since the installation of the required packages happens successfully anyways.
However seeing big bright red error messages confuses majorly during setup and it's a simple fix with wheel.