### PR TITLE
Changed layout of buttons to flex-end and moved description down a line

### DIFF
--- a/application/src/tira/frontend-vuetify/src/submission-components/UploadSubmission.vue
+++ b/application/src/tira/frontend-vuetify/src/submission-components/UploadSubmission.vue
@@ -46,16 +46,20 @@
           </v-window-item>
           <v-window-item v-for="us in this.all_uploadgroups" :value="us.id">
             <loading :loading="description === 'no-description'"/>
-            <div v-if="description !== 'no-description'" class="d-flex justify-lg-space-between">
-              <edit-submission-details type='upload' :id="us.id" :user_id="user_id_for_task" @edit="(i) => updateUploadDetails(i)"/>
-              <v-btn variant="outlined" color="red" @click="deleteUpload(us.id)"><v-tooltip
-                activator="parent"
-                location="bottom"
-              >Attention! This deletes the container and ALL runs associated with it</v-tooltip><v-icon>mdi-delete-alert-outline</v-icon>Delete</v-btn>
+            <div v-if="description !== 'no-description'" class="d-flex flex-column">
 
-              <br>
-              <p>{{ description }}</p>
-              <br>
+              <div class="d-flex justify-end">
+                <edit-submission-details class="mr-3" type='upload' :id="us.id" :user_id="user_id_for_task" @edit="(i) => updateUploadDetails(i)"/>
+                <v-btn variant="outlined" color="red" @click="deleteUpload(us.id)"><v-tooltip
+                  activator="parent"
+                  location="bottom"
+                >Attention! This deletes the container and ALL runs associated with it</v-tooltip><v-icon>mdi-delete-alert-outline</v-icon>Delete</v-btn>
+
+              </div>
+              <div class="my-5">
+                <p>{{ description }}</p>
+              </div>
+
             </div>
             <v-form v-if="description !== 'no-description'">
               <v-file-input v-model="fileHandle"


### PR DESCRIPTION
Buttons are now aligned at the end of line

before:

![](https://user-images.githubusercontent.com/73996300/277297375-537256ca-f3fa-4d40-8cc3-0b3e1b7f54e0.png)


after:

<img width="1693" alt="image" src="https://github.com/tira-io/tira/assets/73996300/0c1d21d9-8659-4928-bd6b-7a795085d8ca">
