### PR TITLE
Tabs in run list are now displayed as select on mobile view

### DIFF
--- a/application/src/tira/frontend-vuetify/src/components/SoftwareDetails.vue
+++ b/application/src/tira/frontend-vuetify/src/components/SoftwareDetails.vue
@@ -1,6 +1,7 @@
 <template>
-  <v-card v-if="!loading" flat class="px-0 mx-0" max-width="75vw">
-    <v-tabs v-model="component_tab" show-arrows>
+  <v-card v-if="!loading" flat class="px-0 mx-0">
+    <v-select class="d-md-none" v-model="selectedComponentTab" label="Select item to get more information" :items="tabs"></v-select>
+    <v-tabs v-model="component_tab" show-arrows class="d-sm-none d-sx-none d-md-block">
       <v-tab value="details">Details</v-tab>
       <v-tab value="references">References</v-tab>
       <v-tab value="reproduction">Reproduction</v-tab>
@@ -115,8 +116,10 @@ export default {
       references_bibtex: 'Loading...',
       details_not_visible: false,
       role: extractRole(), // Values: user, participant, admin,
-      tab: null,
-      component_tab: null,
+      tabs: ['details', 'references', 'reproduction', 'actions'],
+      selectedComponentTab: 'details',
+      tab: '',
+      component_tab: '',
     }
   },
   computed: {
@@ -138,13 +141,17 @@ export default {
       get('/task/' + this.task_id + '/vm/' + this.run.vm_id + '/run_details/' + this.run.run_id)
         .then(inject_response(this, {'loading': false}))
         .catch(() => {this.details_not_visible = true; this.loading = false})
-      }
+      },
+    updateTab() {
+      this.component_tab = this.selectedComponentTab
+    }
   },
   beforeMount() {this.fetchData()},
   watch: {
     run(o, n) {this.fetchData()},
     task_id(o, n) {this.fetchData()},
     columns_to_skip(o, n) {this.fetchData()},
+    selectedComponentTab(o, n) {this.updateTab()}
   }
 }
 </script>


### PR DESCRIPTION
Tabs are now displayed as select on mobile

<img width="970" alt="image" src="https://github.com/tira-io/tira/assets/73996300/562ec910-f4f0-4ec9-8e42-8f668e7ff184">

and still with tabs on desktop

<img width="1170" alt="image" src="https://github.com/tira-io/tira/assets/73996300/37e0b62d-a4f5-42bf-b169-5be30741eb52">
