### PR TITLE
made overflow-y hidden in App.vue

### DIFF
--- a/application/src/tira/frontend-vuetify/src/App.vue
+++ b/application/src/tira/frontend-vuetify/src/App.vue
@@ -8,6 +8,9 @@
 </template>
 
 <style>
+  #app main{
+    overflow-y: hidden;
+  }
   #app input {
     margin: 0px !important;
     padding: 0px !important;


### PR DESCRIPTION
Added overflow-y hidden property for main element. I tried it in the browser dev tools and it made the second scroll-bar disappear for me. 