### PR TITLE
Changed Layout of docker help details

### DIFF
--- a/application/src/tira/frontend-vuetify/src/submission-components/NewDockerSubmission.vue
+++ b/application/src/tira/frontend-vuetify/src/submission-components/NewDockerSubmission.vue
@@ -75,8 +75,9 @@ cat tira-evaluation/evaluation.prototext" expand_message="(3) Verify the evaluat
             <h3 class="text-h6 font-weight-light my-6">
               Please specify your docker software
             </h3>
-              <p class="mb-4">A software submission consists of a docker image and the command that is executed in the docker image. Please specify both below.</p>
+              <p>A software submission consists of a docker image and the command that is executed in the docker image. Please specify both below.</p>
 
+              <p class="my-4 d-flex align-start"> Choose either an existing docker image... </p>
             <v-autocomplete
                 label="Docker Image"
                 :items="docker_images"
@@ -87,6 +88,15 @@ cat tira-evaluation/evaluation.prototext" expand_message="(3) Verify the evaluat
                 :disabled="loading"
                 clearable
                 :rules="[v => !!(v && v.length) || 'Please select the docker image for the execution.']"/>
+              <v-btn
+                      class="mr-4"
+                      color="primary"
+                      :loading="refreshingInProgress"
+                      @click="refreshImages()"
+                    >
+                      refresh images
+              </v-btn>
+              <span><br v-if="$vuetify.display.mdAndDown">last refreshed: {{docker_images_last_refresh}}</span>
             </div>
                <div class="text-center mb-4">
                 <v-dialog
@@ -96,21 +106,15 @@ cat tira-evaluation/evaluation.prototext" expand_message="(3) Verify the evaluat
                   <template v-slot:activator="{ props }" class="d-flex flex-column align-center" >
                     <div>
                     <v-btn
-                      class="mr-2"
+                      class="d-flex mr-2 mb-4 mt-6 align-start"
                       color="primary"
+                      variant="plain"
                       v-bind="props"
                     >
-                      Push New Docker Image
-                    </v-btn>
-                     <v-btn
-                      color="primary"
-                      :loading="refreshingInProgress"
-                      @click="refreshImages()"
-                    >
-                      refresh images
+                      <span v-if="!$vuetify.display.mdAndDown">...or see instructions on how to add a new docker image to tira</span>
+                      <span v-if="$vuetify.display.mdAndDown">...or add new image</span>
                     </v-btn>
                    </div>
-                    <span>last refreshed: {{docker_images_last_refresh}}</span>
                   </template>
 
                   <v-card>


### PR DESCRIPTION
Changed Layout of docker_help details. 

Mobile: 
<img width="387" alt="image" src="https://github.com/tira-io/tira/assets/73996300/04793c85-b752-4bdf-86e6-8d59adf3309c">

Desktop:

<img width="1624" alt="image" src="https://github.com/tira-io/tira/assets/73996300/33c11e50-86c4-4a8a-9abf-ba97c2c725ca">

This still opens a modal as before, but to me the flow seems easier to understand:

<img width="1671" alt="image" src="https://github.com/tira-io/tira/assets/73996300/62066ab8-31b4-4437-8e30-405b322ae80e">
