### PR TITLE
Feature test persist run file

### DIFF
--- a/python-client/tests/test_persisting_run_files.py
+++ b/python-client/tests/test_persisting_run_files.py
@@ -1,6 +1,9 @@
 from tira.third_party_integrations import persist_and_normalize_run
 import pandas as pd
 import unittest
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from math import nan
 
 # .. todo:: there are no assertions in this file
 
@@ -17,3 +20,35 @@ class TestPersistingRunFiles(unittest.TestCase):
     def test_variant_03(self):
         run = pd.DataFrame([{"qid": "1", "score": "1", "docno": "d1"},  {"qid": "1", "score": "0", "docno": "d2"},  {"qid": "1", "score": "2", "docno": "d3"}])
         persist_and_normalize_run(run, 'system_name')
+
+    def test_none_score(self):
+        run = pd.DataFrame([
+            {"qid": "1", "score": "1", "docno": "d1"},
+            {"qid": "1", "score": "0", "docno": "d2"},
+            {"qid": "1", "score": None, "docno": "d3"},
+        ])
+        with TemporaryDirectory() as tmp_dir:
+            run_file_path = Path(tmp_dir) / "run.txt"
+
+            persist_and_normalize_run(
+                run, 'system_name', output_file=str(run_file_path))
+            
+            with run_file_path.open("rt") as run_file:
+                for i, line in enumerate(run_file):
+                    assert len(line.split()) == 6, f"Line {i} does not have exactly 6 columns."
+
+    def test_nan_score(self):
+        run = pd.DataFrame([
+            {"qid": "1", "score": "1", "docno": "d1"},
+            {"qid": "1", "score": "0", "docno": "d2"},
+            {"qid": "1", "score": nan, "docno": "d3"},
+        ])
+        with TemporaryDirectory() as tmp_dir:
+            run_file_path = Path(tmp_dir) / "run.txt"
+
+            persist_and_normalize_run(
+                run, 'system_name', output_file=str(run_file_path))
+            
+            with run_file_path.open("rt") as run_file:
+                for i, line in enumerate(run_file):
+                    assert len(line.split()) == 6, f"Line {i} does not have exactly 6 columns."


### PR DESCRIPTION
The `persist_and_normalize_run` method currently creates invalid run files when the run `DataFrame`'s `score` column contains `nan` or `None` values.
The proposed tests are meant to detect exactly this bug, in order to be fixed.