### PR TITLE
Add feature selection and mapping to PyTerrier integration

### DIFF
--- a/python-client/tira/pyterrier_integration.py
+++ b/python-client/tira/pyterrier_integration.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+import numpy as np
+
 
 class PyTerrierIntegration():
     def __init__(self, tira_client):
@@ -145,21 +147,55 @@ class PyTerrierIntegration():
 
         return generic(__transform_df)
 
-    def doc_features(self, approach, dataset, file_selection=('/*.jsonl', '/*.jsonl.gz')):
-        import numpy as np
-        from pyterrier.apply import doc_features
-        ret = self.pd.transform_documents(approach, dataset, file_selection)
-        cols = [i for i in ret.columns if i not in ['docno']]
-        ret = {str(i['docno']): np.array([i[c] for c in cols]) for _, i in ret.iterrows()}
+    @staticmethod
+    def _get_features_from_row(row, cols, map_features=None):
+        res = []
 
-        return doc_features(lambda row: ret[str(row['docno'])])
+        for c in cols:
+            if map_features is not None and c in map_features:
+                f = map_features[c](row[c])
+            else:
+                f = row[c]
 
-    def query_features(self, approach, dataset, file_selection=('/*.jsonl', '/*.jsonl.gz')):
-        import numpy as np
+            if isinstance(f, (list, np.ndarray)):
+                res.extend(f)
+            else:
+                res.append(f)
+
+        return np.array(res)
+
+    def doc_features(self, approach, dataset, file_selection=('/*.jsonl', '/*.jsonl.gz'), feature_selection=None, map_features=None):
         from pyterrier.transformer import Transformer
+
+        ret = self.pd.transform_documents(approach, dataset, file_selection)
+
+        cols = [col for col in ret.columns if col not in {'docno'}]
+        if feature_selection is not None:
+            cols = [col for col in cols if col in feature_selection]
+
+        ret = {str(row['docno']): self._get_features_from_row(row, cols, map_features) for _, row in ret.iterrows()}
+
+        class ApplyDocFeatureTransformer(Transformer):
+            def __repr__(self):
+                return "tira.pt.doc_features()"
+
+            def transform(self, inputRes):
+                outputRes = inputRes.copy()
+                outputRes["features"] = outputRes.apply(lambda i: ret[str(i['docno'])], axis=1)
+                return outputRes
+
+        return ApplyDocFeatureTransformer()
+
+    def query_features(self, approach, dataset, file_selection=('/*.jsonl', '/*.jsonl.gz'), feature_selection=None, map_features=None):
+        from pyterrier.transformer import Transformer
+
         ret = self.pd.transform_queries(approach, dataset, file_selection)
-        cols = [i for i in ret.columns if i not in ['qid']]
-        ret = {str(i['qid']): np.array([i[c] for c in cols]) for _, i in ret.iterrows()}
+
+        cols = [col for col in ret.columns if col not in {'qid'}]
+        if feature_selection is not None:
+            cols = [col for col in cols if col in feature_selection]
+
+        ret = {str(row['qid']): self._get_features_from_row(row, cols, map_features) for _, row in ret.iterrows()}
 
         class ApplyQueryFeatureTransformer(Transformer):
             def __repr__(self):
@@ -167,7 +203,6 @@ class PyTerrierIntegration():
 
             def transform(self, inputRes):
                 outputRes = inputRes.copy()
-                
                 outputRes["features"] = outputRes.apply(lambda i: ret[str(i['qid'])], axis=1)
                 return outputRes
         


### PR DESCRIPTION
This PR improves `tira.pt.doc_features` and `tira.pt.query_features` by adding two parameters:

- `feature_selection`: allows for filtering the features to be included in the transformer. For instance, if the TIRA component returns columns `a`, `b`, and `c`, setting `feature_selection=('a', 'b')` ensures only `a` and `b` are actually added to the `features` column.
- `map_features`: allows a custom transformation of specific features. For instance, if column `a` is a categorical variable with values `A`, `B`, and `C`, setting `map_features={'a': one_hot_encode(('A', 'B', 'C'))}` can help transform the `a` column into three features, one-hot-encoding the values `A`, `B` and `C`.