### PR TITLE
Moved the tira RestClient and LocalClient into an _internal package

### DIFF
--- a/application/src/tira/frontend-vuetify/src/submission-components/UploadSubmission.vue
+++ b/application/src/tira/frontend-vuetify/src/submission-components/UploadSubmission.vue
@@ -275,10 +275,10 @@ export default {
       handleModifiedSubmission(editedDetails, this.all_uploadgroups)
     },
     batch_upload_code(display_name) {
-      return 'from tira.rest_api_client import Client\n' +
+      return 'from tira.tira_client import RestClient\n' +
         'from pathlib import Path\n' +
         'from tqdm import tqdm\n\n' +
-        'tira = Client()\n' +
+        'tira = RestClient()\n' +
         'approach = \'' + this.task_id + '/' + this.user_id_for_task + '/' + display_name + '\'\n' +
         'dataset_ids = [' + this.datasets.map((i) => '\'' + i.dataset_id + '\'') + ']\n\n' +
         'for dataset_id in tqdm(dataset_ids):\n' +

--- a/python-client/Makefile
+++ b/python-client/Makefile
@@ -14,7 +14,3 @@ run-tests-legacy:
 	&& ../application/venv/bin/coverage report --data-file=tests/test-coverage/.coverage > tests/test-coverage/coverage-report \
 	&& cd tests/test-coverage \
 	&& ../../../application/venv/bin/coverage-badge -o coverage.svg
-
-docs:
-	docker run --rm -ti -v ${PWD}:/app -w /app webis/tira:python-client-dev-0.0.3 bash -c \
-	    'sphinx-apidoc -o docs tira/ && cd docs && make html'

--- a/python-client/README.md
+++ b/python-client/README.md
@@ -16,19 +16,19 @@ tira-cli login --token YOUR-TOKEN-HERE
 You can download runs of published and unblinded submissions via:
 
 ```
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 
-tira = Client()
+tira = RestClient()
 output = tira.get_run_output('<task>/<team>/<approach>', '<dataset>')
 ```
 
 As an example, you can download all baseline BM25 runs submitted to [TIREx](https://www.tira.io/tirex) via:
 
 ```
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 from tira.tirex import TIREX_DATASETS
 
-tira = Client()
+tira = RestClient()
 
 for dataset in TIREX_DATASETS:
     output = tira.get_run_output('ir-benchmarks/tira-ir-starter/BM25 Re-Rank (tira-ir-starter-pyterrier)', dataset)
@@ -39,9 +39,9 @@ for dataset in TIREX_DATASETS:
 As an example, you can see all public software submissions submitted to [TIREx](https://www.tira.io/tirex) via:
 
 ```
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 
-tira = Client()
+tira = RestClient()
 submissions = tira.all_softwares("ir-benchmarks")
 ```
 
@@ -56,9 +56,9 @@ tira-run --export-dataset '<task>/<tira-dataset>' --output-directory tira-datase
 
 Export a dataset via the python API:
 ```
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 
-tira = Client()
+tira = RestClient()
 tira.download_dataset('<task>', '<tira-dataset>')
 ```
 

--- a/python-client/tests/input_run_mount_test.py
+++ b/python-client/tests/input_run_mount_test.py
@@ -1,4 +1,4 @@
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 from tira.third_party_integrations import ensure_pyterrier_is_loaded
 import os
 import pandas as pd
@@ -6,7 +6,7 @@ import unittest
 
 def get_input_run_mounts(input_run, approach_identifier):
     os.environ['inputRun'] = input_run
-    actual_dir = Client().input_run_in_sandbox(approach_identifier)
+    actual_dir = RestClient().input_run_in_sandbox(approach_identifier)
     del os.environ['inputRun']
     actual_files = []
     try:
@@ -18,7 +18,7 @@ def get_input_run_mounts(input_run, approach_identifier):
 
 def tira_cli_download_run_output(input_run, approach_identifier):
     os.environ['inputRun'] = input_run
-    actual_dir = Client().get_run_output(approach_identifier, 'dataset')
+    actual_dir = RestClient().get_run_output(approach_identifier, 'dataset')
     del os.environ['inputRun']
     actual_files = []
     try:
@@ -30,7 +30,7 @@ def tira_cli_download_run_output(input_run, approach_identifier):
 
 def tira_cli_download_dataset(dataset_path):
     os.environ['TIRA_INPUT_DATASET'] = dataset_path
-    actual_dir = Client().download_dataset(None, 'dataset')
+    actual_dir = RestClient().download_dataset(None, 'dataset')
     del os.environ['TIRA_INPUT_DATASET']
     actual_files = []
     try:
@@ -45,7 +45,7 @@ def get_pt_index_in_sandbox(input_run, approach_identifier):
     os.environ['inputRun'] = input_run
 
     try:
-        ret = Client().pt.index(approach_identifier, 'dataset_id')
+        ret = RestClient().pt.index(approach_identifier, 'dataset_id')
         del os.environ['inputRun']
         return ret
     except:
@@ -57,7 +57,7 @@ def get_pt_from_submission_in_sandbox(input_run, approach_identifier):
     os.environ['inputRun'] = input_run
 
     try:
-        ret = Client().pt.from_submission(approach_identifier, 'dataset_id')
+        ret = RestClient().pt.from_submission(approach_identifier, 'dataset_id')
         del os.environ['inputRun']
         return ret
     except:

--- a/python-client/tests/pd_load_data_test.py
+++ b/python-client/tests/pd_load_data_test.py
@@ -1,9 +1,9 @@
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 import unittest
 
 class TestLocalExecutionIntegrationTest(unittest.TestCase):
     def test_pd_load_inputs_wows_re_ranking(self):
-        tira = Client()
+        tira = RestClient()
         actual = tira.pd.inputs('workshop-on-open-web-search', 're-ranking-20231027-training')
         self.assertEqual(6, len(actual))
         self.assertEqual('hubble telescope achievements', actual.iloc[0]['query'])
@@ -12,7 +12,7 @@ class TestLocalExecutionIntegrationTest(unittest.TestCase):
         self.assertEqual('1', actual.iloc[0]['qid'])
 
     def test_pd_load_truths_wows_re_ranking(self):
-        tira = Client()
+        tira = RestClient()
         actual = tira.pd.truths('workshop-on-open-web-search', 're-ranking-20231027-training')
         self.assertEqual(3, len(actual))
         self.assertEqual('hubble telescope achievements', actual.iloc[0]['query'])

--- a/python-client/tests/print_license_agreement_test.py
+++ b/python-client/tests/print_license_agreement_test.py
@@ -1,4 +1,3 @@
-from tira.rest_api_client import Client
 from tira.tira_redirects import redirects
 import unittest
 from contextlib import redirect_stdout

--- a/python-client/tests/pt_document_processing_loader_test.py
+++ b/python-client/tests/pt_document_processing_loader_test.py
@@ -1,4 +1,4 @@
-from tira.local_client import Client
+from tira.tira_client import LocalClient
 
 import pandas as pd
 import unittest
@@ -7,7 +7,7 @@ import unittest
 
 def keyphrase_extraction(docs):
     queries = pd.DataFrame([{'docno': str(i)} for i in docs])
-    tira = Client('tests/resources/')
+    tira = LocalClient('tests/resources/')
     query_segmentation =  tira.pt.transform_documents('ir-benchmarks/webis-keyphrase-extraction/BCExtractorFO', dataset='d1')
     
     ret = query_segmentation(queries)
@@ -16,7 +16,7 @@ def keyphrase_extraction(docs):
 
 def doc_processor(docs, name):
     queries = pd.DataFrame([{'docno': str(i)} for i in docs])
-    tira = Client('tests/resources/')
+    tira = LocalClient('tests/resources/')
     query_segmentation =  tira.pt.transform_documents('ir-benchmarks/tira-ir-starters/' + name, dataset='d1')
     
     ret = query_segmentation(queries)
@@ -64,7 +64,7 @@ class TestPtDocumentProcessingLoaderTest(unittest.TestCase):
         expected = ['value']
 
         documents = pd.DataFrame([{'docno': str(i)} for i in ['doc-01']])
-        tira = Client('tests/resources/')
+        tira = LocalClient('tests/resources/')
         doc_features =  tira.pt.doc_features('ir-benchmarks/tira-ir-starters/tiny-example-02', dataset='d1')
     
         actual = doc_features(documents)
@@ -76,7 +76,7 @@ class TestPtDocumentProcessingLoaderTest(unittest.TestCase):
         expected = ['value']
 
         documents = pd.DataFrame([{'docno': str(i)} for i in ['doc-01']])
-        tira = Client('tests/resources/')
+        tira = LocalClient('tests/resources/')
         doc_features =  tira.pt.doc_features('ir-benchmarks/tira-ir-starters/tiny-example-01', dataset='d1')
     
         actual = doc_features(documents)

--- a/python-client/tests/pt_from_retriever_for_re_ranking_submission_loader_test.py
+++ b/python-client/tests/pt_from_retriever_for_re_ranking_submission_loader_test.py
@@ -1,4 +1,4 @@
-from tira.local_client import Client
+from tira.tira_client import LocalClient
 
 import pandas as pd
 import unittest
@@ -7,7 +7,7 @@ import unittest
 
 def retrieval_submission(queries):
     queries = pd.DataFrame([{'qid': str(i)} for i in queries])
-    tira = Client('tests/resources/')
+    tira = LocalClient('tests/resources/')
     retriever =  tira.pt.from_retriever_submission('ir-benchmarks/tira-ir-starters/retriever-for-re-ranking', dataset='d1')
     
     ret = retriever(queries)

--- a/python-client/tests/pt_from_retriever_submission_loader_test.py
+++ b/python-client/tests/pt_from_retriever_submission_loader_test.py
@@ -1,4 +1,4 @@
-from tira.local_client import Client
+from tira.tira_client import LocalClient
 
 import pandas as pd
 import unittest
@@ -8,7 +8,7 @@ import json
 
 def retrieval_submission(queries):
     queries = pd.DataFrame([{'qid': str(i)} for i in queries])
-    tira = Client('tests/resources/')
+    tira = LocalClient('tests/resources/')
     retriever =  tira.pt.from_retriever_submission('ir-benchmarks/tira-ir-starters/retriever', dataset='d1')
     
     ret = retriever(queries)
@@ -31,7 +31,7 @@ class TestPtFromRetrieverSubmissionLoaderTest(unittest.TestCase):
 
     def test_cascading_with_retriever_is_idempotent_01(self):
         queries = pd.DataFrame([{'qid': str(i)} for i in [1]])
-        tira = Client('tests/resources/')
+        tira = LocalClient('tests/resources/')
         retriever =  tira.pt.from_retriever_submission('ir-benchmarks/tira-ir-starters/retriever', dataset='d1')
     
         ret = (retriever >> retriever).search(queries)
@@ -40,7 +40,7 @@ class TestPtFromRetrieverSubmissionLoaderTest(unittest.TestCase):
 
     def test_cascading_with_retriever_is_idempotent_02(self):
         queries = pd.DataFrame([{'qid': str(i)} for i in [1]])
-        tira = Client('tests/resources/')
+        tira = LocalClient('tests/resources/')
         retriever =  tira.pt.from_retriever_submission('ir-benchmarks/tira-ir-starters/retriever', dataset='d1')
     
         ret = (retriever >> retriever >> retriever >> retriever).search(queries)
@@ -49,7 +49,7 @@ class TestPtFromRetrieverSubmissionLoaderTest(unittest.TestCase):
 
     def test_cascading_with_retriever_is_idempotent_03(self):
         queries = pd.DataFrame([{'qid': str(i)} for i in [1]])
-        tira = Client('tests/resources/')
+        tira = LocalClient('tests/resources/')
         retriever =  tira.pt.from_retriever_submission('ir-benchmarks/tira-ir-starters/retriever', dataset='d1')
     
         ret = ((retriever >> retriever >> retriever >> retriever) >> (retriever >> retriever >> retriever >> retriever)).search(queries)
@@ -58,7 +58,7 @@ class TestPtFromRetrieverSubmissionLoaderTest(unittest.TestCase):
 
     def test_feature_union_from_retriever_01(self):
         queries = pd.DataFrame([{'qid': str(i)} for i in [1]])
-        tira = Client('tests/resources/')
+        tira = LocalClient('tests/resources/')
         retriever =  tira.pt.from_retriever_submission('ir-benchmarks/tira-ir-starters/retriever', dataset='d1')
     
         ret = (retriever >>(retriever ** retriever)).search(queries)
@@ -68,7 +68,7 @@ class TestPtFromRetrieverSubmissionLoaderTest(unittest.TestCase):
 
     def test_feature_union_from_retriever_02(self):
         queries = pd.DataFrame([{'qid': str(i)} for i in [1]])
-        tira = Client('tests/resources/')
+        tira = LocalClient('tests/resources/')
         retriever =  tira.pt.from_retriever_submission('ir-benchmarks/tira-ir-starters/retriever', dataset='d1')
     
         ret = (retriever >>(retriever ** retriever ** retriever ** retriever)).search(queries)
@@ -98,11 +98,11 @@ class TestPtFromRetrieverSubmissionLoaderTest(unittest.TestCase):
         self.assertEqual(actual[0], expected[0])
 
     def test_retrieval_submission_from_rest_api(self):
-        from tira.rest_api_client import Client
+        from tira.tira_client import RestClient
         from tira.third_party_integrations import ensure_pyterrier_is_loaded
         import pyterrier as pt
         ensure_pyterrier_is_loaded()
-        tira = Client()
+        tira = RestClient()
 
         q = tira.pt.from_submission('ir-benchmarks/tira-ir-starter/BM25 Re-Rank (tira-ir-starter-pyterrier)', pt.get_dataset("irds:disks45/nocr/trec-robust-2004"))
         self.assertEqual(len(q(pd.DataFrame([{'qid': '306'}]))), 1000)
@@ -112,11 +112,11 @@ class TestPtFromRetrieverSubmissionLoaderTest(unittest.TestCase):
         self.assertEqual(q(pd.DataFrame([{'qid': '306'}])).iloc[999].to_dict()['qid'], '306')
 
     def test_retrieval_submission_from_rest_api_different_id(self):
-        from tira.rest_api_client import Client
+        from tira.tira_client import RestClient
         from tira.third_party_integrations import ensure_pyterrier_is_loaded
         import pyterrier as pt
         ensure_pyterrier_is_loaded()
-        tira = Client()
+        tira = RestClient()
 
         q = tira.pt.from_submission('ir-benchmarks/tira-ir-starter/BM25 Re-Rank (tira-ir-starter-pyterrier)', pt.get_dataset("irds:ir-benchmarks/disks45-nocr-trec-robust-2004-20230209-training"))
         self.assertEqual(len(q(pd.DataFrame([{'qid': '306'}]))), 1000)

--- a/python-client/tests/pt_query_processing_loader_test.py
+++ b/python-client/tests/pt_query_processing_loader_test.py
@@ -1,11 +1,11 @@
-from tira.local_client import Client
+from tira.tira_client import LocalClient, RestClient
 
 import pandas as pd
 import unittest
 
 def query_segmentation(queries):
     queries = pd.DataFrame([{'qid': str(i)} for i in queries])
-    tira = Client('tests/resources/')
+    tira = LocalClient('tests/resources/')
     query_segmentation =  tira.pt.transform_queries('ir-benchmarks/webis-query-segmentation/wt-snp-baseline', dataset='d1')
     
     ret = query_segmentation(queries)
@@ -34,27 +34,24 @@ class TestQueryProcessingLoader(unittest.TestCase):
         ensure_pyterrier_is_loaded()
 
     def test_rest_query_submission_with_rest_api_01(self):
-        from tira.rest_api_client import Client
-        tira = Client()
+        tira = RestClient()
 
         q = tira.pt.transform_queries('ir-benchmarks/ows/query-segmentation-wt-snp', 'disks45-nocr-trec-robust-2004-20230209-training')
         self.assertEqual(len(q(pd.DataFrame([{'qid': '303'}]))), 1)
         self.assertEqual(q(pd.DataFrame([{'qid': '303'}])).iloc[0].to_dict()['segmentation'], ['hubble telescope achievements'])
 
     def test_rest_query_submission_with_rest_api_02(self):
-        from tira.rest_api_client import Client
-        tira = Client()
+        tira = RestClient()
 
         q = tira.pt.transform_queries('ir-benchmarks/ows/query-segmentation-hyb-a', 'disks45-nocr-trec-robust-2004-20230209-training')
         self.assertEqual(len(q(pd.DataFrame([{'qid': '303'}]))), 1)
         self.assertEqual(q(pd.DataFrame([{'qid': '303'}])).iloc[0].to_dict()['segmentation'], ['hubble telescope', 'achievements'])
 
     def test_rest_query_submission_with_rest_api_03(self):
-        from tira.rest_api_client import Client
         from tira.third_party_integrations import ensure_pyterrier_is_loaded
         import pyterrier as pt
         ensure_pyterrier_is_loaded()
-        tira = Client()
+        tira = RestClient()
 
         q = tira.pt.transform_queries('ir-benchmarks/fschlatt/query-health-classification', pt.get_dataset("irds:clueweb09/en/trec-web-2009"))
         self.assertEqual(len(q(pd.DataFrame([{'qid': '26'}]))), 1)
@@ -62,11 +59,10 @@ class TestQueryProcessingLoader(unittest.TestCase):
         self.assertEqual(q(pd.DataFrame([{'qid': '26'}])).iloc[0].to_dict()['median_health_score'], 130.3137)
 
     def test_rest_query_submission_with_rest_api_and_custom_selection(self):
-        from tira.rest_api_client import Client
         from tira.third_party_integrations import ensure_pyterrier_is_loaded
         import pyterrier as pt
         ensure_pyterrier_is_loaded()
-        tira = Client()
+        tira = RestClient()
 
         q = tira.pt.transform_queries('ir-benchmarks/fschlatt/query-health-classification', pt.get_dataset("irds:clueweb09/en/trec-web-2009"), '/q*.jsonl')
         self.assertEqual(len(q(pd.DataFrame([{'qid': '26'}]))), 1)
@@ -74,11 +70,10 @@ class TestQueryProcessingLoader(unittest.TestCase):
         self.assertEqual(q(pd.DataFrame([{'qid': '26'}])).iloc[0].to_dict()['median_health_score'], 130.3137)
 
     def test_rest_query_submission_with_rest_api_04(self):
-        from tira.rest_api_client import Client
         from tira.third_party_integrations import ensure_pyterrier_is_loaded
         import pyterrier as pt
         ensure_pyterrier_is_loaded()
-        tira = Client()
+        tira = RestClient()
 
         q = tira.pt.transform_queries('ir-benchmarks/qpptk/fixed-sealer', pt.get_dataset("irds:disks45/nocr/trec-robust-2004"))
         self.assertEqual(len(q(pd.DataFrame([{'qid': '301'}]))), 1)
@@ -86,11 +81,10 @@ class TestQueryProcessingLoader(unittest.TestCase):
         self.assertEqual(q(pd.DataFrame([{'qid': '301'}])).iloc[0].to_dict()['avg-idf'], 2.4740487603)
 
     def test_rest_query_features(self):
-        from tira.rest_api_client import Client
         from tira.third_party_integrations import ensure_pyterrier_is_loaded
         import pyterrier as pt
         ensure_pyterrier_is_loaded()
-        tira = Client()
+        tira = RestClient()
 
         q = tira.pt.query_features('ir-benchmarks/qpptk/fixed-sealer', pt.get_dataset("irds:disks45/nocr/trec-robust-2004"))
         self.assertEqual(len(q(pd.DataFrame([{'qid': '301'}]))), 1)

--- a/python-client/tests/resources/corpus-graph-with-pyterrier-index.py
+++ b/python-client/tests/resources/corpus-graph-with-pyterrier-index.py
@@ -3,7 +3,7 @@ import pathlib
 import pandas as pd
 import argparse
 from tira.third_party_integrations import ensure_pyterrier_is_loaded
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 from tqdm import tqdm
 
 def load_oracle_index(file_name):
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     oracle_index = load_oracle_index(args.query_document_pairs)
 
     # This method ensures that that PyTerrier is loaded so that it also works in the TIRA sandbox
-    tira = Client()
+    tira = RestClient()
     ensure_pyterrier_is_loaded()
     import pyterrier as pt
 

--- a/python-client/tests/resources/keyquery-script.py
+++ b/python-client/tests/resources/keyquery-script.py
@@ -3,9 +3,8 @@ import pathlib
 import pandas as pd
 import argparse
 from tira.third_party_integrations import ensure_pyterrier_is_loaded
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 from tqdm import tqdm
-from pathlib import Path
 
 
 def __normalize_queries(q):
@@ -132,7 +131,7 @@ if __name__ == '__main__':
     ensure_pyterrier_is_loaded()
     import pyterrier as pt
 
-    tira = Client()
+    tira = RestClient()
 
     pt_dataset = pt.get_dataset(f'irds:ir-benchmarks/{args.input_dataset}')
     oracle_index = load_oracle_index(args.query_document_pairs, args.oracle_dataset_ids)

--- a/python-client/tests/resources/pyterrier-notebook-without-previous-stages.py
+++ b/python-client/tests/resources/pyterrier-notebook-without-previous-stages.py
@@ -1,8 +1,9 @@
 from tira.third_party_integrations import ensure_pyterrier_is_loaded, persist_and_normalize_run
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 ensure_pyterrier_is_loaded()
 import pyterrier as pt
-tira = Client()
+
+tira = RestClient()
 dataset_id = 'longeval-tiny-train-20240315-training'
 pt_dataset = pt.get_dataset(f'irds:ir-lab-padua-2024/{dataset_id}')
 index = load_index()

--- a/python-client/tests/resources/retrieve-with-pyterrier-index.ipynb
+++ b/python-client/tests/resources/retrieve-with-pyterrier-index.ipynb
@@ -23,14 +23,14 @@
    "outputs": [],
    "source": [
     "from tira.third_party_integrations import ensure_pyterrier_is_loaded, persist_and_normalize_run\n",
-    "from tira.rest_api_client import Client\n",
+    "from tira.tira_client import RestClient\n",
     "\n",
     "# This method ensures that that PyTerrier is loaded so that it also works in the TIRA sandbox\n",
     "ensure_pyterrier_is_loaded()\n",
     "import pyterrier as pt\n",
     "from tqdm import tqdm\n",
     "\n",
-    "tira = Client()"
+    "tira = RestClient()"
    ]
   },
   {

--- a/python-client/tests/resources/retrieve-with-pyterrier-index.py
+++ b/python-client/tests/resources/retrieve-with-pyterrier-index.py
@@ -1,8 +1,8 @@
 from tira.third_party_integrations import ensure_pyterrier_is_loaded, persist_and_normalize_run
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 ensure_pyterrier_is_loaded()
 import pyterrier as pt
-tira = Client()
+tira = RestClient()
 dataset_id = 'longeval-tiny-train-20240315-training'
 pt_dataset = pt.get_dataset(f'irds:ir-lab-padua-2024/{dataset_id}')
 index = tira.pt.index('ir-benchmarks/tira-ir-starter/Index (tira-ir-starter-pyterrier)', dataset_id)

--- a/python-client/tests/resources/retrieve-with-pyterrier.ipynb
+++ b/python-client/tests/resources/retrieve-with-pyterrier.ipynb
@@ -23,14 +23,14 @@
    "outputs": [],
    "source": [
     "from tira.third_party_integrations import ensure_pyterrier_is_loaded, persist_and_normalize_run\n",
-    "from tira.rest_api_client import Client\n",
+    "from tira.tira_client import RestClient\n",
     "\n",
     "# This method ensures that that PyTerrier is loaded so that it also works in the TIRA sandbox\n",
     "ensure_pyterrier_is_loaded()\n",
     "import pyterrier as pt\n",
     "from tqdm import tqdm\n",
     "\n",
-    "tira = Client()"
+    "tira = RestClient()"
    ]
   },
   {

--- a/python-client/tests/rest_api_test.py
+++ b/python-client/tests/rest_api_test.py
@@ -1,14 +1,14 @@
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient, TiraClient
 import unittest
 
 # .. todo:: this file still uses "unclean" assertions and should be converted to use unittest assertions
 
 class TestRestAPI(unittest.TestCase):
-    tira: Client
+    tira: TiraClient
 
     @classmethod
     def setUpClass(cls):
-        TestRestAPI.tira = Client()
+        TestRestAPI.tira = RestClient()
 
     def test_all_softwares_works_for_tirex(self):
         actual = TestRestAPI.tira.all_softwares("ir-benchmarks")

--- a/python-client/tests/test_tira_redicrects.py
+++ b/python-client/tests/test_tira_redicrects.py
@@ -1,7 +1,7 @@
 import unittest
 from approvaltests import verify_as_json
 from tira.tira_redirects import redirects, mirror_url
-from tira.rest_api_client import Client
+from tira.tira_client import RestClient
 import requests
 from hashlib import md5
 
@@ -166,7 +166,7 @@ class TestRedirects(unittest.TestCase):
             'longeval-short-july-20230513-training', 'longeval-heldout-20230513-training',
             'longeval-long-september-20230513-training', 'longeval-train-20230513-training'
         ])
-        tira = Client()
+        tira = RestClient()
 
         ret = {}
         for software in softwareto_approve:

--- a/python-client/tests/test_utils.py
+++ b/python-client/tests/test_utils.py
@@ -1,7 +1,7 @@
 import requests
 from hashlib import md5
-from tira.tira_redirects import redirects, mirror_url
-from tira.rest_api_client import Client
+from tira.tira_redirects import redirects
+from tira.tira_client import RestClient
 
 def md5_of_first_kilobyte_of_http_resource(url):
     #if not url.startswith('https://files.webis.de'):
@@ -36,7 +36,7 @@ def digest_of_dataset(dataset_id, truth=False):
     }
 
 def digest_of_run_output(approach, dataset_id, run_ids):
-    tira = Client()
+    tira = RestClient()
     task, team, system = approach.split('/')
     run_url = f'https://www.tira.io/task/{task}/user/{team}/dataset/{dataset_id}/download/{run_ids[task][team][system][dataset_id]}.zip'
 

--- a/python-client/tira/_internal/local_client.py
+++ b/python-client/tira/_internal/local_client.py
@@ -1,17 +1,19 @@
+from typing import Optional
+
 import json
 import pandas as pd
 import os
 from glob import glob
 from packaging import version
-from tira.pyterrier_integration import PyTerrierIntegration
-from tira.pandas_integration import PandasIntegration
-from tira.local_execution_integration import LocalExecutionIntegration
-from tira.rest_api_client import Client as RestClient
-from tira.tira_client import TiraClient
+from ..pyterrier_integration import PyTerrierIntegration
+from ..pandas_integration import PandasIntegration
+from ..local_execution_integration import LocalExecutionIntegration
+from ..tira_client import TiraClient
+from .rest_api_client import Client as RestClient
 
 
 class Client(TiraClient):
-    def __init__(self, directory='.', rest_client=None):
+    def __init__(self, directory='.', rest_client: Optional[TiraClient] = None):
         self.pd = PandasIntegration(self)
         self.pt = PyTerrierIntegration(self)
         self.directory = directory + '/'

--- a/python-client/tira/_internal/rest_api_client.py
+++ b/python-client/tira/_internal/rest_api_client.py
@@ -11,7 +11,7 @@ from tira.pyterrier_integration import PyTerrierIntegration, PyTerrierAnceIntegr
 from tira.pandas_integration import PandasIntegration
 from tira.local_execution_integration import LocalExecutionIntegration
 import logging
-from .tira_client import TiraClient
+from ..tira_client import TiraClient
 from typing import Optional, List, Dict, Union
 from functools import lru_cache
 from tira.tira_redirects import redirects, mirror_url, dataset_ir_redirects, RESOURCE_REDIRECTS
@@ -305,7 +305,6 @@ class Client(TiraClient):
         if team:
             ret = ret[ret['team'] == team]
 
-        # FIXME: Is this really necessary or is it checked with the if len(ret) <= 0 later on?
         if len(ret) <= 0:
             return None
 

--- a/python-client/tira/ir_datasets_util.py
+++ b/python-client/tira/ir_datasets_util.py
@@ -262,7 +262,7 @@ def ir_dataset_from_tira_fallback_to_original_ir_datasets():
             logging.info(f'Please pass tira_path as <task>/<tira-dataset>. Got {tira_path}')
             raise ValueError(f'Please pass tira_path as <task>/<tira-dataset>. Got {tira_path}')
 
-        from tira.rest_api_client import Client as RestClient
+        from tira.tira_client import RestClient
         task, dataset = tira_path.split('/')
         return RestClient().download_dataset(task, dataset, truth_dataset=truth_dataset)
 

--- a/python-client/tira/third_party_integrations.py
+++ b/python-client/tira/third_party_integrations.py
@@ -75,7 +75,7 @@ def load_rerank_data(default, load_default_text=True):
     default_input = get_input_directory_and_output_directory(default)[0]
 
     if not os.path.isdir(default_input) and len(default.split('/')) == 2:
-        from tira.rest_api_client import Client as RestClient
+        from tira.tira_client import RestClient
         default_input = RestClient().download_dataset(default.split('/')[0], default.split('/')[1])
 
     if not default_input.endswith('rerank.jsonl') and not default_input.endswith('rerank.jsonl.gz'):

--- a/python-client/tira/tira_cli.py
+++ b/python-client/tira/tira_cli.py
@@ -4,12 +4,8 @@ from platform import python_version
 from typing import Optional
 
 from tira import __version__
-from tira.rest_api_client import Client as RestClient
+from .tira_client import RestClient
 import logging
-
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from .tira_client import TiraClient
 
 
 def download_run(client, approach, dataset):
@@ -49,7 +45,7 @@ Implementations of each command. They don't all need to be here but if your comm
 don't know, where else to put it, this is a good place.
 """
 def download_command(dataset: str, approach: Optional[str]=None, **kwargs) -> int:
-    client: "TiraClient" = RestClient()
+    client = RestClient()
     if approach is not None:
         print(client.get_run_output(approach, dataset))
     else:
@@ -57,7 +53,7 @@ def download_command(dataset: str, approach: Optional[str]=None, **kwargs) -> in
     return 0
 
 def login_command(token: str, print_docker_auth: bool, **kwargs) -> int:
-    client: "TiraClient" = RestClient()
+    client = RestClient()
     client.login(token)
     if print_docker_auth:
         print(client.local_execution.docker_client_is_authenticated())

--- a/python-client/tira/tira_client.py
+++ b/python-client/tira/tira_client.py
@@ -95,3 +95,14 @@ class TiraClient(ABC):
         false  otherwise.
         """
         pass
+
+
+
+
+def RestClient(base_url: "Optional[str]"=None, api_key: str=None, failsave_retries: int=5, failsave_max_delay: int=15, api_user_name: "Optional[str]"=None) -> TiraClient:
+    from ._internal.rest_api_client import Client as TiraRestClient
+    return TiraRestClient(base_url=base_url, api_key=api_key, failsave_retries=failsave_retries, failsave_max_delay=failsave_max_delay, api_user_name=api_user_name)
+
+def LocalClient(directory='.', rest_client: "Optional[TiraClient]"=None) -> TiraClient:
+    from ._internal.local_client import Client as TiraLocalClient
+    return TiraLocalClient(directory=directory, rest_client=rest_client)

--- a/python-client/tira/tira_redirects.py
+++ b/python-client/tira/tira_redirects.py
@@ -444,7 +444,7 @@ def mirror_url(url):
     return url
 
 # do some semi fast tests with:
-#    python3 -c 'from tira.rest_api_client import Client; tira = Client(); print(tira.get_run_output("ir-benchmarks/tira-ir-starter/Index (tira-ir-starter-pyterrier)", "argsme-touche-2020-task-1-20230209-training"))'
+#    python3 -c 'from tira.tira_client import RestClient; tira = RestClient(); print(tira.get_run_output("ir-benchmarks/tira-ir-starter/Index (tira-ir-starter-pyterrier)", "argsme-touche-2020-task-1-20230209-training"))'
 
 def redirects(approach=None, dataset=None, url=None):
     default_ret = {'urls': [url]}

--- a/python-client/tira/tira_run.py
+++ b/python-client/tira/tira_run.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python
 import argparse
-from tira.local_client import Client
-from tira.rest_api_client import Client as RestClient
+from .tira_client import LocalClient, RestClient
 from tira.local_execution_integration import LocalExecutionIntegration
 from tira.io_utils import huggingface_model_mounts
 import os
 import shutil
 import logging
+from pathlib import Path
 import tempfile
 from tira.third_party_integrations import extract_previous_stages_from_docker_image
-
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from .tira_client import TiraClient
 
 
 def setup_upload_run_command(parser: argparse.ArgumentParser) -> None:
@@ -171,7 +167,7 @@ def main(args=None):
     args = args if args else parse_args()
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
-    client: "TiraClient" = Client()
+    client = LocalClient()
 
     # Subcommands store their executable into args.executable which takes the parsed arguments and returns an integer
     if hasattr(args, 'executable') and args.executable is not None:


### PR DESCRIPTION
This PR aims to better distinguish between the private and public API and properly hide implementation details.

Previously, the TiraClient abstract base class was only used for type hinting. With this change, the user only sees the methods `RestClient(...) -> TiraClient` and `LocalClient(...) -> TiraClient` instead of the concrete implementations to reduce cognitive load. This is a breaking API change since the imports must be updated to:

```py
from tira.tira_client import RestClient, LocalClient
```
instead of
```py
from tira.rest_api_client import Client as RestClient
from tira.local_client import Client as LocalClient
```

The new "private" submodule `tira._internal` can also be used for further implementation-details that should not be part of the public API (e.g., some of the utilities @mam10eks?).