### PR TITLE
added missing submissions_of_team method

### DIFF
--- a/python-client/tira/rest_api_client.py
+++ b/python-client/tira/rest_api_client.py
@@ -228,6 +228,11 @@ class Client(TiraClient):
 
         return pd.DataFrame(ret)
 
+    def submissions_of_team(self, task, dataset, team):
+        submissions = self.submissions(task, dataset)
+        filtered_submissions = submissions[submissions['team'] == team]
+        return filtered_submissions
+
     def upload_submissions(self, task_id, vm_id, upload_id, dataset=None):
         ret = self.json_response(f"/api/upload-group-details/{task_id}/{vm_id}/{upload_id}")
         ret = ret["context"]["upload_group_details"]["runs"]


### PR DESCRIPTION
`tira.rest_api_client.Client.get_run_execution_or_none` calls `submissions_of_team`, which isn't defined. This PR adds this missing method.