### PR TITLE
Configured linters to run on PR

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -3,6 +3,7 @@ name: Linters
 on:
   push: {}
   workflow_dispatch: {}
+  pull_request: {}
 
 jobs:
   mypy:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -9,23 +9,24 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4
+        continue-on-error: false
       - name: Set up Python 3.9
+        continue-on-error: false
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install mypy
         run: pip3 install mypy
       - name: Run mypy on backend
-        continue-on-error: true
         working-directory: ${{github.workspace}}/application
         run: |
           mkdir .mypy_cache
           mypy . --non-interactive --cache-dir=.mypy_cache/
       - name: Run mypy on python-client
-        continue-on-error: true
         working-directory: ${{github.workspace}}/python-client
         run: |
           mkdir .mypy_cache
@@ -37,20 +38,21 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        continue-on-error: false
       - name: Set up Python 3.9
+        continue-on-error: false
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install flake8
         run: pip3 install flake8
       - name: Run flake8 on backend
-        continue-on-error: true
         working-directory: ${{github.workspace}}/application
         run: flake8 .
       - name: Run flake8 on python-client
-        continue-on-error: true
         working-directory: ${{github.workspace}}/python-client
         run: flake8 .
       - name: Fail Never
@@ -60,9 +62,12 @@ jobs:
   black:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        continue-on-error: false
       - name: Set up Python 3.9
+        continue-on-error: false
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
@@ -78,9 +83,12 @@ jobs:
   isort:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        continue-on-error: false
       - name: Set up Python 3.9
+        continue-on-error: false
         uses: actions/setup-python@v4
         with:
           python-version: 3.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Unit Tests
 
-on: [push]
+on:
+  push: {}
+  workflow_dispatch: {}
+  pull_request: {}
 
 jobs:
   backend-tests:


### PR DESCRIPTION
It seems that our tests and linters don't run on external pull requests. [GitHub's docs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/approving-workflow-runs-from-public-forks) say that we have to manually approve runs but I have not seen that button yet. With this PR I want to test if I can make it appear by explicitly setting the workflows to run on `pull_request`.