### PR TITLE
Add pyyaml to python-client dependencies

### DIFF
--- a/python-client/setup.cfg
+++ b/python-client/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     packaging
     tqdm
     gitpython
+    pyyaml
 
 [options.extras_require]
 test =


### PR DESCRIPTION
YAML is required to validate the `ir-metadata.yml` submission format in `tira-upload`. This is not automatically installed when using `uv tool add tira` and requires `uv tool add tira --with pyyaml`.

I ran into this issue while trying to upload to LongEval 2025 without pyyaml in a clean python environment.

```
> tira-cli upload --dataset web-20250430-test --directory .\bm25_submission\ --system dsgt-bm25-submission
I check that the submission in directory '.\bm25_submission\' is valid...


        ✖ The file bm25_submission/ir-metadata.yml is not valid. Errors: No module named 'yaml'

Result:
        ✖ Could not upload to TIRA as the directory bm25_submission is not a valid submission.
```


