### PR TITLE
Configure Redis as the default Results Backend

### DIFF
--- a/.devcontainer/docker-compose.dev.yml
+++ b/.devcontainer/docker-compose.dev.yml
@@ -11,13 +11,14 @@ services:
       # TIRA Worker Environment Variables
       TIRA_WORKER_CONFIG: "/workspaces/tira/worker/tira-worker-config.yml"
       TIRA_BROKER_URL: "amqp://broker.tira.local"
-      TIRA_RESULTS_BACKEND_URL: "rpc://broker.tira.local"
+      TIRA_RESULTS_BACKEND_URL: "redis://results.tira.local:6379/0"
       TIRA_API_KEY: "so-secret"
       TIRA_WELLKNOWN_URL: "https://api.tira.local/.well-known/tira/client"
     external_links:
       - "auth:auth.tira.local"
       - "nginx:api.tira.local"
       - "broker:broker.tira.local"
+      - "results-backend:results.tira.local"
       - "s3mock:s3.tira.local"
     volumes:
       - ./devfiles/s3/.s3cfg:/home/ubuntu/.s3cfg
@@ -38,7 +39,11 @@ services:
     restart: unless-stopped
     ports:
       - "5672:5672"
-      - "15672:15672"
+  results-backend:
+    image: redis:8-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
   s3mock:
     image: adobe/s3mock
     restart: unless-stopped

--- a/documentation/organizers/deployment/demo.rst
+++ b/documentation/organizers/deployment/demo.rst
@@ -13,7 +13,7 @@ Demo Deployment
             restart: unless-stopped
             environment:
                 TIRA_BROKER_URL: "amqp://broker.tira.local"
-                TIRA_RESULTS_BACKEND_URL: "rpc://broker.tira.local"
+                TIRA_RESULTS_BACKEND_URL: "redis://results.tira.local:6379/0"
             external_links:
                 - "broker:broker.tira.local"
         tira-frontend:
@@ -28,7 +28,7 @@ Demo Deployment
             restart: unless-stopped
             environment:
                 TIRA_BROKER_URL: "amqp://broker.tira.local"
-                TIRA_RESULTS_BACKEND_URL: "rpc://broker.tira.local"
+                TIRA_RESULTS_BACKEND_URL: "redis://results.tira.local:6379/0"
                 TIRA_API_KEY: "so-secret"
                 TIRA_WELLKNOWN_URL: "https://api.tira.local/.well-known/tira/client"
             external_links:
@@ -45,7 +45,11 @@ Demo Deployment
             restart: unless-stopped
             ports:
             - "5672:5672"
-            - "15672:15672"
+        results-backend:
+            image: redis:8-alpine
+            restart: unless-stopped
+            ports:
+            - "6379:6379"
         s3mock:
             image: adobe/s3mock
             restart: unless-stopped

--- a/worker/setup.cfg
+++ b/worker/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    celery[librabbitmq]
+    celery[librabbitmq,redis]
     pyaml-env==1.2.1
 
 [options.extras_require]

--- a/worker/src/tira_worker/_tasks.py
+++ b/worker/src/tira_worker/_tasks.py
@@ -15,12 +15,12 @@ import os
 from shutil import copytree
 
 app = Celery("tira-tasks", backend=QUEUE_RESULTS_BACKEND_URL, broker=QUEUE_BROKER_URL)
-app.conf.control_queue_exclusive = True
-app.conf.control_queue_durable = False
+app.conf.control_queue_exclusive = True  # Not required after celery 5.7 is released
+app.conf.control_queue_durable = False  # Not required after celery 5.7 is released
 
 gpu_executor = Celery("tira-gpu-executor", backend=QUEUE_RESULTS_BACKEND_URL, broker=QUEUE_BROKER_URL)
-app.conf.control_queue_exclusive = True
-app.conf.control_queue_durable = False
+gpu_executor.conf.control_queue_exclusive = True  # Not required after celery 5.7 is released
+gpu_executor.conf.control_queue_durable = False  # Not required after celery 5.7 is released
 
 MONITORED_EXECUTION_POLL_INTERVAL_SECONDS = 90
 
@@ -91,7 +91,11 @@ def execute_monitored(method: Callable, client: "Optional[TiraClient]" = None, j
                 print("Failed to load running processes")
                 running_process_response = None
 
-            if running_process_response and  "killing" in running_process_response and running_process_response["killing"]:
+            if (
+                running_process_response
+                and "killing" in running_process_response
+                and running_process_response["killing"]
+            ):
                 print("I will kill all running containers...")
                 client.local_execution.kill_all_running_containers()
                 print("The running containers are killed...")
@@ -146,6 +150,7 @@ def run(
         )
     else:
         software_workflow_configuration["image"] = docker_image
+
         def run_tmp(i):
             run_results = run_workflow(
                 system_inputs,
@@ -155,11 +160,11 @@ def run(
                 allow_network=allow_network,
                 additional_volumes=hf_models,
                 gpu_device_ids=gpu_devices,
-                tira=client
+                tira=client,
             )
             os.rmdir(i)
             copytree(run_results.run / "output", i)
-            
+
             try:
                 print((run_results.run / "stdout.txt").read_text())
             except:

--- a/worker/src/tira_worker/_tasks.py
+++ b/worker/src/tira_worker/_tasks.py
@@ -15,7 +15,13 @@ import os
 from shutil import copytree
 
 app = Celery("tira-tasks", backend=QUEUE_RESULTS_BACKEND_URL, broker=QUEUE_BROKER_URL)
+app.conf.control_queue_exclusive = True
+app.conf.control_queue_durable = False
+
 gpu_executor = Celery("tira-gpu-executor", backend=QUEUE_RESULTS_BACKEND_URL, broker=QUEUE_BROKER_URL)
+app.conf.control_queue_exclusive = True
+app.conf.control_queue_durable = False
+
 MONITORED_EXECUTION_POLL_INTERVAL_SECONDS = 90
 
 

--- a/worker/tira-worker-config.yml
+++ b/worker/tira-worker-config.yml
@@ -13,4 +13,4 @@ debug: !ENV ${TIRA_DEBUG:false}
 ##########################################################################################
 # See also: https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html
 queue_broker_url: !ENV ${TIRA_BROKER_URL:amqp://localhost"}
-queue_results_backend_url: !ENV ${TIRA_RESULTS_BACKEND_URL:rpc://localhost}
+queue_results_backend_url: !ENV ${TIRA_RESULTS_BACKEND_URL:redis://localhost:6379/0}


### PR DESCRIPTION
This PR
- Install redis dependency
- Configures Redis as the default results backend (for deployment and dev container)
- Sets the default values that will be set with Celery 5.7 to be compatible with RabbitMQ 4.3 (Delete those lines when Celery 5.7 is out)